### PR TITLE
Add light on/off macro

### DIFF
--- a/klipper_config/lights.cfg
+++ b/klipper_config/lights.cfg
@@ -1,2 +1,10 @@
 [output_pin caselights]
 pin: z:P2.5
+
+[gcode_macro caselights_on]
+gcode:
+    set_pin pin=caselights value = 1
+
+[gcode_macro caselights_off]
+gcode:
+    set_pin pin=caselights value = 0

--- a/klipper_config/lights.cfg
+++ b/klipper_config/lights.cfg
@@ -3,8 +3,8 @@ pin: z:P2.5
 
 [gcode_macro caselights_on]
 gcode:
-    set_pin pin=caselights value = 1
+    set_pin pin=caselights value=1
 
 [gcode_macro caselights_off]
 gcode:
-    set_pin pin=caselights value = 0
+    set_pin pin=caselights value=0


### PR DESCRIPTION
Allows a macro button in mainsail

Todo: use caselight/hour_counter macros rather than setting pins in other gcodes. 