### PR TITLE
Use heater_fan for hour counter on/off

### DIFF
--- a/klipper_config/hour_counter.cfg
+++ b/klipper_config/hour_counter.cfg
@@ -1,10 +1,7 @@
-[output_pin hour_counter]
+[heater_fan hour_counter]
 pin: P2.5
-
-[gcode_macro hour_counter_on]
-gcode:
-    set_pin pin=hour_counter value=1
-
-[gcode_macro hour_counter_off]
-gcode:
-    set_pin pin=hour_counter value=0
+max_power: 1
+shutdown_speed: 1
+heater: extruder
+heater_temp: 150
+fan_speed: 1.0

--- a/klipper_config/macros/start_end.cfg
+++ b/klipper_config/macros/start_end.cfg
@@ -25,7 +25,6 @@ gcode:
     M117 Heating
     M109 S{EXTRUDER}
     CLEAN_NOZZLE
-    HOUR_COUNTER_ON
     M400
     M83
     G92 E0
@@ -45,7 +44,6 @@ gcode:
     M107                           ; turn off fan
     G1 Z2 F3000                    ; move nozzle up 2mm
     PARK
-    HOUR_COUNTER_OFF
     M400                           ; wait for buffer to clear
     M106 S255                      ; Turn on fan, cool down faster
     M140 S0                        ; Turn off bed

--- a/klipper_config/pause_resume.cfg
+++ b/klipper_config/pause_resume.cfg
@@ -7,7 +7,6 @@ default_parameter_Y: 300
 default_parameter_Z: 10
 gcode:
     G1 E-4.3 F2000
-    HOUR_COUNTER_OFF
     CLEAR_PAUSE
     SDCARD_RESET_FILE
     BASE_CANCEL_PRINT
@@ -19,7 +18,6 @@ default_parameter_Y: 300
 default_parameter_Z: 10
 gcode:
     SAVE_GCODE_STATE NAME=PAUSE
-    HOUR_COUNTER_OFF
     BASE_PAUSE
     G91
     G1 E-1.7 F2000
@@ -31,7 +29,6 @@ gcode:
 [gcode_macro RESUME]
 rename_existing: BASE_RESUME
 gcode:
-    HOUR_COUNTER_ON
     G91
     G1 E1.7 F2000
     G91


### PR DESCRIPTION
Switches to a `heater_fan` to automatically turn on/off the hour counter based on extruder temperature.  This makes our configuration simpler as we don't have to explicitly call `HOUR_COUNTER_{ON,OFF}` during start/pause/cancel/end.